### PR TITLE
added several installation aliases and aliases for 'winpty'

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ sudo pip install gevent
 Collecting gevent...
 ```
 
-You will be asked for UAC acception (if it is enabled) and then a new session will be opened as a sub-shell.
+You will be prompted for UAC acception (if enabled) and then a new session will be spawned as a sub-shell.
 
 ### su
 

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-echo "Downloading win-sudo...";trap 'echo "Failed to install, sorry :(";exit 1' ERR
-mkdir -p ~/bin/win-sudo && cd "$_";git init -q && git config core.sparsecheckout true;echo s/ >> .git/info/sparse-checkout
-git remote add -mf origin https://github.com/imachug/win-sudo.git && git pull -q origin master
-echo "source ~/bin/win-sudo/s/path.sh" | tee -a ~/.bashrc ~/.bash_profile /etc/profile >/dev/null 2>&1
-echo "Win-sudo successfully installed!";exec bash
+shopt -s expand_aliases
+cat <(curl -s https://raw.githubusercontent.com/imachug/win-sudo/master/installaliases) >> ~/.bashrc && . ~/.bashrc;ws-start-script
+mkdir -pv ~/bin/win-sudo && cd "$_";init-gitrepo-setup && gramf https://github.com/imachug/win-sudo.git && git pull -q base master
+echo "source ~/bin/win-sudo/s/path.sh" | tee -a ws-files null && echo "source ~/bin/win-sudo/s/aliases" >>~/.bashrc && ws-success

--- a/installaliases
+++ b/installaliases
@@ -1,0 +1,17 @@
+function ws-script-start {
+  echo "Downloading win-sudo..."
+  trap 'echo "Failed to install, sorry :("; exit 1' ERR
+}
+function ws-success {
+  echo Win-sudo successfully installed!
+  exec bash
+  alias fresh="exec bash"
+}
+function init-gitrepo-setup {
+  git init -q
+  git config core.sparsecheckout true
+  echo s/ >> .git/info/sparse-checkout
+}
+alias gramf="git remote add -mf base"
+alias ws-files="~/.bashrc ~/.bash_profile /etc/profile"
+alias null=">/dev/null 2>&1"

--- a/s/aliases
+++ b/s/aliases
@@ -1,0 +1,3 @@
+shopt -s expand_aliases
+alias wi="winpty" #Usage : wi [command] / sudo wi [command]
+alias swi="sudo winpty" #Usage : swi [command]


### PR DESCRIPTION
Okay I decided to take my previous PR a step father adding several aliases that make sudo slightly easier to use. I created two regular files : 'installaliases' and 'aliases'. The 'installaliases' files contains several aliases for install.sh. The 'aliases' file contains a few aliases for winpty. The 'aliases' file is not a finished product, as this repo grows larger more and more aliases may be added to make usage easier.  I also made a minor change to the wording in README.md.

File operation locations : 
* installaliases : file contents are appended to ~/.bashrc
* aliases : added to s/, export command added to ~/.bashrc

Aliases : 
* wi = winpty
* swi = sudo winpty

PLEASE NOTE : The `cat` command that I'm using includes `<()`, which is a relatively new syntax for git. If you are using an older version of git this might not work.