### PR TITLE
work around strange cygwin bug

### DIFF
--- a/s/sudo
+++ b/s/sudo
@@ -38,7 +38,7 @@ echo "$command_to_run" >"$fifoid.command"
 for fd in 0 1 2; do
 	if [ -t $fd ]; then
 		# Terminal
-		echo "/proc/$$/fd/$fd" >"$fifoid.fd$fd"
+		readlink "/proc/$$/fd/$fd" >"$fifoid.fd$fd"
 	else
 		# Not terminal
 		mkfifo "$fifoid.pipe$fd"


### PR DESCRIPTION
Somehow accessing the filedescriptor in current cygwin (3.0.7(0.338/5/3)) results in 
`-bash: echo: write error: Bad file descriptor`
resolving the link to  /dev/pty? fixes this.

Maybe #36 is related to that.