### PR TITLE
bugfix: support spaces in args

### DIFF
--- a/s/sudo
+++ b/s/sudo
@@ -1,6 +1,17 @@
 #!/bin/bash
 
-command_to_run="$*"
+command_to_run=''
+for arg in "$@"; do
+    case "$arg" in
+        *\'*)
+            arg="$(printf "%s" "$arg" | sed "s/'/'\"'\"'/g")"
+            ;;
+        *) : ;;
+    esac
+    [[ -n "$command_to_run" ]] && command_to_run="$command_to_run "
+    command_to_run="$command_to_run'$arg'"
+done
+
 if [ -z "$command_to_run" ]; then
 	echo "Usage: sudo command"
 	echo "Runs command with administrator privileges."
@@ -17,7 +28,7 @@ if [ $ret -eq 127 ]; then
 fi
 if [ $ret -eq 0 ]; then
 	#if elevated just run command
-	exec $command_to_run
+	exec "$command_to_run"
 fi
 
 
@@ -60,14 +71,14 @@ function clean {
 trap clean EXIT
 
 # Run command
-powershell.exe Start-Process \"$(cygpath -w /bin/)bash\" \"$backend\", \"$fifoid\", \"$(pwd)\" -Verb RunAs -WindowStyle Hidden 2>/dev/null
+powershell.exe Start-Process \""$(cygpath -w /bin/)"bash\" \"$backend\", \"$fifoid\", \""$PWD"\" -Verb RunAs -WindowStyle Hidden 2>/dev/null
 if [ $? -ne 0 ]; then
 	echo "UAC elevation was canceled" >&2
 	exit 1
 fi
 
 # Get pid
-pid=$(cat "$fifoid.pidf")
+pid="$(cat "$fifoid.pidf")"
 
 # Wait
 trap "echo 1 >\"$fifoid.sigint\" && sleep 0.1" SIGINT

--- a/s/sudobackend
+++ b/s/sudobackend
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -x
-
 fifoid="$1"
 
 cd "$2" || exit 1

--- a/s/sudobackend
+++ b/s/sudobackend
@@ -1,11 +1,14 @@
 #!/bin/bash
-cd "$2"
 
-fifoid=$1
+set -x
+
+fifoid="$1"
+
+cd "$2" || exit 1
 
 source "$fifoid.env"
 
-command_to_run=$(< "$fifoid.command")
+command_to_run="$(< "$fifoid.command")"
 stdin=$(< "$fifoid.fd0")
 stdout=$(< "$fifoid.fd1")
 stderr=$(< "$fifoid.fd2")
@@ -16,7 +19,7 @@ echo $pid >"$fifoid.pidf"
 
 while true; do
 	sigint=$(< "$fifoid.sigint")
-	if [ ! -z "$sigint" ]; then
+	if [ -n "$sigint" ]; then
 		if [ "$sigint" -eq 2 ]; then
 			break
 		fi


### PR DESCRIPTION
This PR fixes an issue where args are not being passed through correct. e.g.:

```
sudo bash -c 'echo hello world'
```

Actually runs:

```
bash -c echo hello world
```

which in turn doesn't actually fully work:

```
$ bash -c echo hello world

```

With this change, it correctly executes:

```
'bash' '-c' 'echo hello world'
```

Which in turns means:

```
$ 'bash' '-c' 'echo hello world'
hello world
```