### PR TITLE
Prevent cd in backend

### DIFF
--- a/s/sudo
+++ b/s/sudo
@@ -71,8 +71,8 @@ function clean {
 trap clean EXIT
 
 # Run command
-powershell.exe Start-Process \""$(cygpath -w /bin/)"bash\" \"$backend\", \"$fifoid\", \""$PWD"\" -Verb RunAs -WindowStyle Hidden 2>/dev/null
-if [ $? -ne 0 ]; then
+
+if ! powershell.exe Start-Process \""$(cygpath -w /bin/)"bash\" \""$backend"\", \"$fifoid\" -Verb RunAs -WorkingDirectory "$PWD" -WindowStyle Hidden 2>/dev/null; then
 	echo "UAC elevation was canceled" >&2
 	exit 1
 fi
@@ -96,8 +96,8 @@ for fd in 1 2; do
 done
 
 while true; do
-	res=$(cat "$fifoid.finish")
-	if [ ! -z "$res" ]; then
+	res="$(cat "$fifoid.finish")"
+	if [ -n "$res" ]; then
 		break
 	fi
 done

--- a/s/sudobackend
+++ b/s/sudobackend
@@ -2,29 +2,27 @@
 
 fifoid="$1"
 
-cd "$2" || exit 1
-
 source "$fifoid.env"
 
 command_to_run="$(< "$fifoid.command")"
-stdin=$(< "$fifoid.fd0")
-stdout=$(< "$fifoid.fd1")
-stderr=$(< "$fifoid.fd2")
+stdin="$(< "$fifoid.fd0")"
+stdout="$(< "$fifoid.fd1")"
+stderr="$(< "$fifoid.fd2")"
 
 $SHELL -c "$command_to_run" >"$stdout" 2>"$stderr" <"$stdin" &
-pid=$!
-echo $pid >"$fifoid.pidf"
+pid="$!"
+echo "$pid" >"$fifoid.pidf"
 
 while true; do
-	sigint=$(< "$fifoid.sigint")
+	sigint="$(< "$fifoid.sigint")"
 	if [ -n "$sigint" ]; then
 		if [ "$sigint" -eq 2 ]; then
 			break
 		fi
-		kill -s SIGINT $pid
+		kill -s SIGINT "$pid"
 	fi
 done &
 
-wait $pid
+wait "$pid"
 echo 2 >"$fifoid.sigint"
 echo 1 >"$fifoid.finish"


### PR DESCRIPTION
This PR includes some shellcheck improvements (not all), but more importantly, it takes the responsibility of changing the dir away from the backend, and instead relies on `Start-Process` to set the working directory.