### PR TITLE
Bugfix install.sh path to bashrc with spaces

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,13 +5,13 @@ echo "Downloading win-sudo..."
 trap "echo Failed to install, sorry :(; exit 1" ERR
 
 # Clean default install dir
-if [ -d ~/bin/win-sudo ] ; then
-	echo "Cleaning ~/bin/win-sudo..."
-	rm -rfv ~/bin/win-sudo
+if [ -d "$HOME/bin/win-sudo" ] ; then
+	echo "Cleaning $HOME/bin/win-sudo..."
+	rm -rfv "$HOME/bin/win-sudo"
 fi
 
 # Download latest sources to a fresh directory 
-mkdir -pv ~/bin/win-sudo
+mkdir -pv "$HOME/bin/win-sudo"
 cd "$_"
 git init -q
 git config core.sparsecheckout true
@@ -21,17 +21,17 @@ git pull -q base master
 
 # Start processing bash initialization files
 # We're leaving out /.profile to avoid permission issues (at least in Git Bash)
-touch ~/.bashrc
-for f in ~/.bashrc ~/.bash_profile
+touch "$HOME/.bashrc"
+for f in "$HOME/.bashrc" "$HOME/.bash_profile"
 do
 	echo "Processing $f"
-	if [ -f $f ] ; then
-		if grep -q "source ~/bin/win-sudo/s/path.sh" $f ; then
+	if [ -f "$f" ] ; then
+		if grep -q "source \"$HOME/bin/win-sudo/s/path.sh\"" "$f" ; then
 			echo "Sudo initialization already in file " $f
 			break
 		else
 			echo "Appending sudo initialization to " $f
-			echo "[ -f ~/bin/win-sudo/s/path.sh ] && source ~/bin/win-sudo/s/path.sh" >>$f
+			echo "[ -f \"$HOME/bin/win-sudo/s/path.sh\" ] && source \"$HOME/bin/win-sudo/s/path.sh\"" >>"$f"
 			break
 		fi
 	fi

--- a/s/su
+++ b/s/su
@@ -2,4 +2,4 @@
 root_dir="$(realpath "$(dirname "$0")")"
 sudo_path="$root_dir/sudo"
 
-$sudo_path $SHELL --rcfile "$root_dir/sudorc"
+"$sudo_path" $SHELL --rcfile "$root_dir/sudorc"

--- a/s/sudo
+++ b/s/sudo
@@ -33,7 +33,7 @@ fi
 
 
 # get backend path 
-backend="$(realpath ${BASH_SOURCE[0]}backend)"
+backend="$(realpath "${BASH_SOURCE[0]}backend")"
 
 umask 066
 fifoid="/tmp/.sudo.$RANDOM"
@@ -71,8 +71,7 @@ function clean {
 trap clean EXIT
 
 # Run command
-
-if ! powershell.exe Start-Process \""$(cygpath -w /bin/)"bash\" \""$backend"\", \"$fifoid\" -Verb RunAs -WorkingDirectory "$PWD" -WindowStyle Hidden 2>/dev/null; then
+if ! powershell.exe Start-Process \""$(cygpath -w /bin/)"bash\" \""$backend"\", \"$fifoid\" -Verb RunAs -WorkingDirectory \""$PWD"\" -WindowStyle Hidden\; \(\$Error[0]\).InvocationInfo.Line; then
 	echo "UAC elevation was canceled" >&2
 	exit 1
 fi

--- a/s/sudo
+++ b/s/sudo
@@ -71,7 +71,7 @@ function clean {
 trap clean EXIT
 
 # Run command
-if ! powershell.exe Start-Process \""$(cygpath -w /bin/)"bash\" \""$backend"\", \"$fifoid\" -Verb RunAs -WorkingDirectory \""$PWD"\" -WindowStyle Hidden\; \(\$Error[0]\).InvocationInfo.Line; then
+if ! powershell.exe Start-Process \""$(cygpath -w /bin/)"bash\" \""$backend"\", \"$fifoid\" -Verb RunAs -WorkingDirectory \"\$PWD\" -WindowStyle Hidden\; \(\$Error[0]\).InvocationInfo.Line; then
 	echo "UAC elevation was canceled" >&2
 	exit 1
 fi


### PR DESCRIPTION
Currently, if username has a space, script will fail; path to bashrc/bash_profile gets broken up
```
$ curl -s https://raw.githubusercontent.com/imachug/win-sudo/master/install.sh | sh
Downloading win-sudo...
mkdir: created directory '/c/Users/Michael Chan/bin'
mkdir: created directory '/c/Users/Michael Chan/bin/win-sudo'
Processing /c/Users/Michael Chan/.bashrc
sh: line 28: [: /c/Users/Michael: binary operator expected
Processing /c/Users/Michael Chan/.bash_profile
sh: line 28: [: /c/Users/Michael: binary operator expected
Win-sudo successfully installed!
```

Have tested fix, ensures spaces in path are handled, resulting in
```
mkdir: created directory '/c/Users/Michael Chan/bin'
mkdir: created directory '/c/Users/Michael Chan/bin/win-sudo'
Processing /c/Users/Michael Chan/.bashrc
Appending sudo initialization to  /c/Users/Michael Chan/.bashrc
Win-sudo successfully installed!
```

And sudo works! 