### PR TITLE
Ensure .git/info exists before accessing it

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,7 @@ mkdir -pv "$HOME/bin/win-sudo"
 cd "$_"
 git init -q
 git config core.sparsecheckout true
+mkdir -p .git/info
 echo s/ >>.git/info/sparse-checkout
 git remote add -mf base https://github.com/imachug/win-sudo.git
 git pull -q base master


### PR DESCRIPTION
Initialising a Git repository doesn't always create the info directory.